### PR TITLE
Implement functionality to seed the posts table

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Faker\Generator as Faker;
+use App\Post;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(Faker $faker)
+    {
+        Post::truncate();
+        for ($i=0; $i < 100; $i++) { 
+            Post::create([
+                'title' => $faker->sentence,
+                'body' => $faker->paragraph
+            ]);
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,9 @@ Inside the project root folder, run the command below in your console
 $ php artisan migrate:fresh
 ```
 ```
+$ php artisan db:seed
+```
+```
 $ php artisan serve
 ```
 ## Running the tests


### PR DESCRIPTION
#### What does this PR do?
- adds the functionality for users to populate the `posts` table with random data
#### Description of Task to be completed?
#### How should this be manually tested?
- clone the repo then checkout to this branch `ch-create-seeder-for-posts-table`
- run composer install
- create a database and put in your creds in the .env
- run `php artisan db:seed`
- run`php artisan serve`
- go to `/posts/` by clicking on `Articles`
#### Any background context you want to provide?
#### What are the relevant stories?
[]()
#### Screenshots (if appropriate)
