### PR TITLE
a user should be able to edit a specific post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 /report
+.php_cs*

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -7,7 +7,6 @@ use App\Post;
 
 class PostsController extends Controller
 {
-
     public function __construct()
     {
         $this->middleware('auth')->except(['index', 'show']);
@@ -52,7 +51,7 @@ class PostsController extends Controller
 
     /**
      * stores new post
-     * 
+     *
      * @return mixed
      */
     public function store(StoreBlogPost $request)
@@ -60,5 +59,30 @@ class PostsController extends Controller
         $validatedPost = $request->validated();
         Post::create($validatedPost);
         return \redirect('posts');
+    }
+
+    /**
+     * returns view for editing a specific post
+     *
+     * @param [type] $id
+     * @return void
+     */
+    public function edit($id)
+    {
+        $post = Post::find($id);
+        return \view('posts.edit', compact('post'));
+    }
+
+    /**
+     * updates existing post
+     *
+     * @return mixed
+     */
+    public function update(StoreBlogPost $request, $id)
+    {
+        $validatedPost = $request->validated();
+        $post = Post::find($id);
+        $post->update($validatedPost);
+        return \redirect("post/$id");
     }
 }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -9,6 +9,6 @@
       <label for="body">Description</label>
       <textarea class="form-control" name="body" id="body" cols="30" rows="10"></textarea>
     </div>
-    <input type="hidden" name="_token" id="token" value="{{ csrf_token() }}">
+    {{ csrf_field() }}
     <button type="submit" class="btn btn-primary">Save Post</button>
 </form>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,14 @@
+<h1>Edit Post</h1>
+<form method="POST" action="/post/{{$post->id}}">
+  {{ method_field('PUT') }}
+    <div class="form-group">
+      <label for="title">Title</label>
+    <input type="text" name="title" class="form-control" id="title" value="{{$post->title}}">
+    </div>
+    <div class="form-group">
+      <label for="body">Description</label>
+      <textarea class="form-control" name="body" id="body" cols="30" rows="10">{{$post->body}}</textarea>
+    </div>
+    {{ csrf_field() }}
+    <button type="submit" class="btn btn-primary">Save Post</button>
+</form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,10 @@ Route::post('/posts', 'PostsController@store');
 
 Route::get('/post/{id}', 'PostsController@show');
 
+Route::get('/post/{id}/edit', 'PostsController@edit');
+
+Route::put('/post/{id}', 'PostsController@update');
+
 Route::get('/posts/create', 'PostsController@create');
 
 Auth::routes();

--- a/tests/Browser/UpdatePostTest.php
+++ b/tests/Browser/UpdatePostTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\User;
+use App\Post;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class UpdatePostTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function userCanViewEditPostPage()
+    {
+        $user = \factory(User::class)->create();
+        $post = \factory(Post::class)->create();
+
+        $this->browse(function(Browser $browser) use($user, $post) {
+            $browser->loginAs($user)
+                    ->visit("/post/{$post->id}/edit")
+                    ->assertSee('Edit');
+        });
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function userCanUpdatePost()
+    {
+        $user = \factory(User::class)->create();
+        $post = \factory(Post::class)->create();
+
+        $this->browse(function(Browser $browser) use($user, $post) {
+            $browser->loginAs($user)
+                    ->visit("/post/{$post->id}/edit")
+                    ->type('title', 'New Title')
+                    ->type('body', 'New Body')
+                    ->press('Save Post')
+                    ->assertPathIs("/post/{$post->id}");
+        });
+    }
+}

--- a/tests/Feature/UpdatePostTest.php
+++ b/tests/Feature/UpdatePostTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\User;
+use App\Post;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UpdatePostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @group view-edit-page
+     * @test
+     *
+     * @return void
+     */
+    public function userShouldBeAbleToViewEditPage()
+    {
+        $post = \factory(Post::class)->create();
+        $this->be(\factory(User::class)->create());
+
+        $response = $this->get("post/{$post->id}/edit");
+
+        $response->assertStatus(200);
+        $response->assertSee('Edit');
+    }
+
+    /**
+     * @group update-post
+     * @test
+     *
+     * @return void
+     */
+    public function aUserShouldBeAbleToUpdatePosts()
+    {
+        $post = \factory(Post::class)->create();
+        $this->be(\factory(User::class)->create());
+        $updatePost = ['title' => 'Update Title', 'body' => 'Update description'];
+
+        $response = $this->put("/post/{$post->id}", $updatePost);
+
+        $response->assertStatus(302); // redirect to the specific post view
+        $this->assertDatabaseHas('posts', ['title' => $updatePost['title']]);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function unauthenticatedUsersCannotViewEditPage()
+    {
+        $post = \factory(Post::class)->create();
+
+        $response = $this->get("post/{$post->id}/edit");
+
+        $response->assertStatus(302); // redirect to login
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
- adds functionality for a user to edit a post
#### Description of Task to be completed?
- write tests
- add routes and endpoint to view edit form
- add functionality to update the post via update method
#### How should this be manually tested?
- clone the repo then checkout to this branch `ft-user-should-edit-post`
- run composer install
- create a database and put in your creds in the .env
- create a sqlite db file for testing `touch database/testing.sqlite`
- run `./vendor/bin/phpunit`
- create an account `/register` and proceed to login if not automatically logged in `/login`
- go to `/posts/create` or run `php artisan db:seed`
- Should be redirected to the `/posts` page if you chose the first one
- Click view details for one of the posts then add `/edit` on the url i.e. `post/{id}/edit`
#### Any background context you want to provide?
N/A
#### What are the relevant stories?
[]()
#### Screenshots (if appropriate)
