### PR TITLE
add relationships and ownership controls

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -14,6 +14,7 @@ class PagesController extends Controller
     public function index()
     {
         if (auth()->user()) {
+            // $user = User::with('posts')->get();
             return \view('home');
         }
         return \view('pages.landing');

--- a/app/Post.php
+++ b/app/Post.php
@@ -12,4 +12,9 @@ class Post extends Model
     {
         return $this->created_at->toFormattedDateString();
     }
+
+    public function author()
+    {
+        return $this->belongsTo('App\User', 'user_id', 'id');
+    }
 }

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -5,6 +5,9 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Broadcast;
 
+/**
+ * @codeCoverageIgnore
+ */
 class BroadcastServiceProvider extends ServiceProvider
 {
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -36,4 +36,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany('App\Post', 'user_id', 'id');
+    }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -7,6 +7,7 @@ use Faker\Generator as Faker;
 
 $factory->define(Post::class, function (Faker $faker) {
     return [
+        'user_id' => 1,
         'title' => $faker->sentence,
         'body' => $faker->paragraph,
     ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -18,7 +18,7 @@ use Faker\Generator as Faker;
 $factory->define(User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
-        'email' => $faker->unique()->safeEmail,
+        'email' => 'test@email.com',
         'email_verified_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),

--- a/database/migrations/2019_05_02_100617_create_posts_table.php
+++ b/database/migrations/2019_05_02_100617_create_posts_table.php
@@ -15,6 +15,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->unsignedInteger('user_id');
             $table->string('title');
             $table->text('body');
             $table->timestamps();

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Faker\Generator as Faker;
 use App\Post;
+use App\User;
 
 class PostsTableSeeder extends Seeder
 {
@@ -14,9 +15,13 @@ class PostsTableSeeder extends Seeder
      */
     public function run(Faker $faker)
     {
+        User::truncate();
+        $user = factory(User::class)->create();
+
         Post::truncate();
         for ($i=0; $i < 100; $i++) { 
             Post::create([
+                'user_id' => $user->id,
                 'title' => $faker->sentence,
                 'body' => $faker->paragraph
             ]);

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,14 @@ $ php artisan db:seed
 ```
 $ php artisan serve
 ```
+##### NB: You can now log in via the following credentials
+```
+email: test@email.com
+```
+```
+password: password
+```
+
 ## Running the tests
 ### Browser tests
 ```

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -16,7 +16,7 @@
     </div>
     <div class="card-footer text-muted">
         Posted on {{$post->createdAt()}} by
-        <a href="#">User Unavailabe ATM</a>
+        <a href="/user/{{$post->author['name']}}">{{$post->author['name']}}</a>
     </div>
 </div>
 

--- a/tests/Browser/CreatePostTest.php
+++ b/tests/Browser/CreatePostTest.php
@@ -19,7 +19,7 @@ class CreatePostTest extends DuskTestCase
     {
         $user = \factory(App\User::class)->create();
 
-        $this->browse(function(Browser $browser) {
+        $this->browse(function (Browser $browser) {
             $browser->loginAs($user)
                 ->visit('/posts/create')
                 ->type('title', 'New Post')
@@ -27,7 +27,7 @@ class CreatePostTest extends DuskTestCase
                 ->press('Save Post')
                 ->assertPathIs('/posts')
                 ->assertSee('New Post');
-        }); 
+        });
     }
 
     /**
@@ -37,9 +37,9 @@ class CreatePostTest extends DuskTestCase
      */
     public function onlyAuthUserCanCreatePost()
     {
-        $this->browse(function(Browser $browser) {
+        $this->browse(function (Browser $browser) {
             $browser->visit('/posts/create')
                 ->assertPathIs('/login');
-        }); 
+        });
     }
 }

--- a/tests/Browser/UpdatePostTest.php
+++ b/tests/Browser/UpdatePostTest.php
@@ -22,7 +22,7 @@ class UpdatePostTest extends DuskTestCase
         $user = \factory(User::class)->create();
         $post = \factory(Post::class)->create();
 
-        $this->browse(function(Browser $browser) use($user, $post) {
+        $this->browse(function (Browser $browser) use ($user, $post) {
             $browser->loginAs($user)
                     ->visit("/post/{$post->id}/edit")
                     ->assertSee('Edit');
@@ -39,7 +39,7 @@ class UpdatePostTest extends DuskTestCase
         $user = \factory(User::class)->create();
         $post = \factory(Post::class)->create();
 
-        $this->browse(function(Browser $browser) use($user, $post) {
+        $this->browse(function (Browser $browser) use ($user, $post) {
             $browser->loginAs($user)
                     ->visit("/post/{$post->id}/edit")
                     ->type('title', 'New Title')

--- a/tests/Browser/UserCanLoginTest.php
+++ b/tests/Browser/UserCanLoginTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Browser;
 
-use App\User; 
+use App\User;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -20,7 +20,7 @@ class UserCanLoginTest extends DuskTestCase
     {
         $user = \factory(User::class)->create();
 
-        $this->browse(function(Browser $browser) use($user) {
+        $this->browse(function (Browser $browser) use ($user) {
             $browser->visit('/login')
                     ->type('email', $user->email)
                     ->type('password', 'password')

--- a/tests/Browser/ViewPostTest.php
+++ b/tests/Browser/ViewPostTest.php
@@ -20,7 +20,7 @@ class ViewPostTest extends DuskTestCase
         $post = \factory(App\Post::class)->create();
         $pos1 = \factory(App\Post::class)->create();
 
-        $this->browse(function(Browser $browser) {
+        $this->browse(function (Browser $browser) {
             $browser->visit('/posts')
                     ->assertSee($post->title)
                     ->clickLink($post1->title)

--- a/tests/Browser/ViewPostsTest.php
+++ b/tests/Browser/ViewPostsTest.php
@@ -20,7 +20,7 @@ class ViewPostsTest extends DuskTestCase
         $post = \factory(App\Post::class)->create();
         $post1 = \factory(App\Post::class)->create();
 
-        $this->browse(function(Browser $browser) {
+        $this->browse(function (Browser $browser) {
             $browser->visit('/posts')
                     ->assertSee($post->title)
                     ->assertSee($post1->title);

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -36,8 +36,10 @@ abstract class DuskTestCase extends BaseTestCase
         ]);
 
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
-                ChromeOptions::CAPABILITY, $options
+            'http://localhost:9515',
+            DesiredCapabilities::chrome()->setCapability(
+                ChromeOptions::CAPABILITY,
+                $options
             )
         );
     }

--- a/tests/Feature/CreateNewPostTest.php
+++ b/tests/Feature/CreateNewPostTest.php
@@ -14,7 +14,7 @@ class CreateNewPostTest extends TestCase
     /**
      * @group view-create-page
      * @test
-     * 
+     *
      * @return void
      */
     public function canViewPageForCreatingPost()
@@ -39,8 +39,7 @@ class CreateNewPostTest extends TestCase
             'title' => 'new Post',
             'body' => 'new post created just now',
         ];
-        $this->be(\factory(User::class)->create());
-
+        $user = $this->be(\factory(User::class)->create());
         //action
         $response = $this->post('/posts', $post);
 

--- a/tests/Feature/DeletePostTest.php
+++ b/tests/Feature/DeletePostTest.php
@@ -20,8 +20,9 @@ class DeletePostTest extends TestCase
      */
     public function userCanDeletePost()
     {
-        $this->be(\factory(User::class)->create());
-        $post = \factory(Post::class)->create();
+        $user = \factory(User::class)->create();
+        $this->be($user);
+        $post = \factory(Post::class)->create(['user_id' => $user->id]);
 
         $response = $this->delete("/post/{$post->id}");
 
@@ -43,5 +44,24 @@ class DeletePostTest extends TestCase
         $response = $this->delete("post/{$nonExistingPostId}");
 
         $response->assertStatus(404);
+    }
+
+    /**
+     * @group non-owner-deletion
+     * @test
+     *
+     * @return void
+     */
+    public function nonOwnerCannotDeletePost()
+    {
+        $user = \factory(User::class)->create();
+        $user1 = \factory(User::class)->create(["email" => "email.test@email.com"]);
+        $this->be($user);
+
+        $post = \factory(Post::class)->create(['user_id' => $user1->id]);
+
+        $response = $this->delete("/post/{$post->id}");
+
+        $response->assertStatus(302);
     }
 }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -11,20 +11,25 @@ class LoginTest extends TestCase
 {
     use RefreshDatabase;
 
-     public function aUserCanViewLoginPage()
-     {
-          $response = $this->get('/login');
-          $response->assertStatus(200);
-          $response->assertSee('Login');
-     }
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function aUserCanViewLoginPage()
+    {
+        $response = $this->get('/login');
+        $response->assertStatus(200);
+        $response->assertSee('Login');
+    }
 
     /**
      * @test
      *
      * @return void
      */
-   public function aUserCanLogIn()
-   {
+    public function aUserCanLogIn()
+    {
         // arrange phase - create user
         $user = \factory(User::class)->create();
 
@@ -33,5 +38,5 @@ class LoginTest extends TestCase
 
         // assertion phase
         $response->assertStatus(302); // returns a redirect
-   }
+    }
 }

--- a/tests/Feature/PagesControllerTest.php
+++ b/tests/Feature/PagesControllerTest.php
@@ -9,7 +9,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PagesControllerTest extends TestCase
 {
-
     use RefreshDatabase;
 
     /**
@@ -38,6 +37,5 @@ class PagesControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('Dashboard');
-
     }
 }

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -9,6 +9,11 @@ class RegisterTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @test
+     *
+     * @return void
+     */
     public function aUserCanViewRegisterPage()
     {
         $response = $this->get('/register');

--- a/tests/Feature/UpdatePostTest.php
+++ b/tests/Feature/UpdatePostTest.php
@@ -20,8 +20,9 @@ class UpdatePostTest extends TestCase
      */
     public function userShouldBeAbleToViewEditPage()
     {
-        $post = \factory(Post::class)->create();
-        $this->be(\factory(User::class)->create());
+        $user = \factory(User::class)->create();
+        $this->be($user);
+        $post = \factory(Post::class)->create(['user_id' => $user->id]);
 
         $response = $this->get("post/{$post->id}/edit");
 
@@ -37,8 +38,10 @@ class UpdatePostTest extends TestCase
      */
     public function aUserShouldBeAbleToUpdatePosts()
     {
-        $post = \factory(Post::class)->create();
-        $this->be(\factory(User::class)->create());
+        $user = \factory(User::class)->create();
+        $this->be($user);
+        $post = \factory(Post::class)->create(['user_id' => $user->id]);
+        
         $updatePost = ['title' => 'Update Title', 'body' => 'Update description'];
 
         $response = $this->put("/post/{$post->id}", $updatePost);
@@ -75,6 +78,24 @@ class UpdatePostTest extends TestCase
         $response = $this->get("post/{$nonExistingPostID}/edit");
 
         $response->assertStatus(404);
+    }
 
+    /**
+     * @group edit-non-owner
+     * @test
+     *
+     * @return void
+     */
+    public function nonPostOwnerShouldNotBeAbleToAccessEditPage()
+    {
+        $user = \factory(User::class)->create();
+        $user1 = \factory(User::class)->create(['email' => 'testmail@email.com']);
+        $this->be($user);
+
+        $post = \factory(Post::class)->create(['user_id' => $user1->id]);
+
+        $response = $this->get("/post/{$post->id}/edit");
+
+        $response->assertStatus(302);
     }
 }

--- a/tests/Feature/ViewAllBlogPostsTest.php
+++ b/tests/Feature/ViewAllBlogPostsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Post;
+use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -19,9 +20,11 @@ class ViewAllBlogPostsTest extends TestCase
     public function userCanViewAllBlogPosts()
     {
         // arrange
-        $post1 = \factory(Post::class)->create();
-        $post2 = \factory(Post::class)->create();
-        $post3 = \factory(Post::class)->create();
+        $user = \factory(User::class)->create();
+        $this->be($user);
+        $post1 = \factory(Post::class)->create(['user_id' => $user->id]);
+        $post2 = \factory(Post::class)->create(['user_id' => $user->id]);
+        $post3 = \factory(Post::class)->create(['user_id' => $user->id]);
 
         // act
         $response = $this->get('/posts');

--- a/tests/Feature/ViewBlogPostTest.php
+++ b/tests/Feature/ViewBlogPostTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Post;
+use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -18,7 +19,9 @@ class ViewBlogPostTest extends TestCase
     public function userCanViewABlogPost()
     {
         // Arrangement step - create an article
-        $post = \factory(Post::class)->create();
+        $user = \factory(User::class)->create();
+        $this->be($user);
+        $post = \factory(Post::class)->create(['user_id' => $user->id]);
 
         // Action step - visit the route
         $response = $this->get("/post/{$post->id}");


### PR DESCRIPTION
#### What does this PR do?
- it adds relationships between authors and posts and also implements ownership controls
#### Description of Task to be completed?
- implement relationships between users and posts
- update the migrations, factories and database seeders
- implement ownership controls
#### How should this be manually tested?
- clone the repo then checkout to this branch `ft-add-relationships-and-ownership-controls`
- run composer install
- create a database and put in your creds in the .env
- create a sqlite db file for testing `touch database/testing.sqlite`
- run `./vendor/bin/phpunit`
#### Any background context you want to provide?
#### What are the relevant stories?
[]()
#### Screenshots (if appropriate)
